### PR TITLE
feat: HTTP 기본 인증을 사용해서 로그인, 로그아웃 엔드포인트 구현

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -63,3 +63,12 @@ class CommentAuthorizationFailedException(HTTPException):
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"{author_id}은(는) 해당 댓글에 대한 권한이 부족하거나 비밀번호가 틀렸습니다.",
         )
+
+
+class NotAuthenticated(HTTPException):
+    def __init__(self):
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="인증 실패",
+            headers={"WWW-Authenticate": "Basic"},
+        )

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,65 @@
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+
+class UserCreationFailedException(HTTPException):
+    def __init__(self, nickname: Optional[str]):
+        super().__init__(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"사용자({nickname}) 생성을 실패했습니다.",
+        )
+
+
+class UserNotFoundException(HTTPException):
+    def __init__(self):
+        super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=f"사용자를 찾을 수 없습니다.")
+
+
+class UserAuthorizationFailedException(HTTPException):
+    def __init__(self):
+        super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=f"비밀번호가 틀렸습니다.")
+
+
+class PostCreationFailedException(HTTPException):
+    def __init__(self, title: str):
+        super().__init__(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"게시글({title}) 생성을 실패했습니다."
+        )
+
+
+class PostNotFoundException(HTTPException):
+    def __init__(self, post_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"번호 '{post_id}' 게시글을 찾을 수 없습니다."
+        )
+
+
+class PostAuthorizationFailedException(HTTPException):
+    def __init__(self, author_id: str):
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN, detail=f"{author_id}은(는) 해당 게시글에 대한 권한이 없습니다."
+        )
+
+
+class CommentCreationFailedException(HTTPException):
+    def __init__(self, post_id: int):
+        super().__init__(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"해당글({post_id})에 댓글 작성을 실패했습니다.",
+        )
+
+
+class CommentNotFoundException(HTTPException):
+    def __init__(self, comment_id: int):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"번호 '{comment_id}' 댓글을 찾을 수 없습니다."
+        )
+
+
+class CommentAuthorizationFailedException(HTTPException):
+    def __init__(self, author_id: str):
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"{author_id}은(는) 해당 댓글에 대한 권한이 부족하거나 비밀번호가 틀렸습니다.",
+        )

--- a/model.py
+++ b/model.py
@@ -1,9 +1,15 @@
 import re
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import validator
 from sqlmodel import Field, Relationship, SQLModel
+
+
+class Role(str, Enum):
+    MEMBER = "member"
+    ADMIN = "admin"
 
 
 class User(SQLModel, table=True):  # type: ignore
@@ -12,6 +18,7 @@ class User(SQLModel, table=True):  # type: ignore
     comments: List["Comment"] = Relationship(back_populates="user")
     password: str = Field()
     nickname: Optional[str] = Field(max_length=20, index=True)
+    role: Role = Field(default=Role.MEMBER, max_length=20)
     created_at: datetime = Field(default=datetime.utcnow())
 
     @validator("password")


### PR DESCRIPTION
### 요약

HTTP 기본 인증을 사용해서 로그인, 로그아웃 엔드포인트 구현

### 변경 사항

- 추가된 엔드포인트
  - /users/login
  - /users/logout

- HTTP 인증(fastapi.security. HTTPBasicCredentials) 으로 세션 처리
